### PR TITLE
Delete .run directory

### DIFF
--- a/.run/Run Subsystems and Scheduler.run.xml
+++ b/.run/Run Subsystems and Scheduler.run.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Subsystems and Scheduler" type="CompoundRunConfigurationType">
-    <toRun name="ElevatorSubsystem" type="Application" />
-    <toRun name="FloorSubsystem" type="Application" />
-    <toRun name="Scheduler" type="Application" />
-    <method v="2" />
-  </configuration>
-</component>


### PR DESCRIPTION
This was my attempt at running all the systems with 1 button click. Apparently, IntelliJi is worse than eclipse at this because you can not control the order in which each main method runs. What we can do to do in IntelliJi is download a plugin such as https://github.com/rkhmelyuk/multirun which will run each main method in a specific order. Order is required as the Host must start before the Client or the Client will not be able to receive anything and end up deadlocked waiting for a packet that will never arrive. Alternatively, we can just run each method manually preferably in the order Scheduler, floorSubsystem, and then elevatorSubsystem.