### PR TITLE
Multirun plugin to run main methods in IntelliJ automated

### DIFF
--- a/.run/Run Scheduler and subsystems.run.xml
+++ b/.run/Run Scheduler and subsystems.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Scheduler and subsystems" type="Multirun" separateTabs="false" reuseTabsWithFailures="false" startOneByOne="true" markFailedProcess="true" hideSuccessProcess="false" delayTime="0.1">
+    <runConfiguration name="Scheduler" type="Application" />
+    <runConfiguration name="FloorSubsystem" type="Application" />
+    <runConfiguration name="ElevatorSubsystem" type="Application" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
Running Multiple Programs at once: 

The order to run the main methods is: Scheduler, FloorSubsystem, ElevatorSubsystem.

Running all the main methods with the click of one button: 

Eclipse: 
... 

IntelliJ: 
...

## Multirun plugin to run main methods in IntelliJ automated
https://plugins.jetbrains.com/plugin/7248-multirun

# Install
You do not need to install this plugin if you are using eclipse. Eclipse has a built-in way to set the order of main method calls.

To install multirun click the setting icon in the top right corner of IntelliJ. Click plugins.

Search multirun in the plugins list. If it does not show up there should be an option to search aftermarket plugins which you can click.

Click install

At this point, multirun should be installed and ready to use.

# Run Notes
If the multi-run configuration does not work instantly. Run all 3 main methods in the elevatorSubsystem, floorSubsystem, and scheduler in any order to add them to the run options. Go to File and click Restart IDE.

I did notice that it is possible that the multirun configuration is overwritten with a blank configuration under certain conditions. To check that the configuration is not being overwritten, check if there is an option to merge a new commit into Github. If there is an option to merge then right-click the change and click rollback.

If the run configuration is still not working then you may want to simply make your own run configuration.

Run -> Edit Configurations...
Find and add a new Multirun configuration
Add other run configurations to the Multirun configuration
Pick options you'd like
Ready to use